### PR TITLE
Make it work fixes & improvements

### DIFF
--- a/ht301_hacklib.py
+++ b/ht301_hacklib.py
@@ -297,6 +297,7 @@ class HT301:
             ret, frame_raw, frame, meta = self.read_()
             device_strings = device_info(meta)
             if device_strings[3] == 'T3-317-13': frame_ok = True
+            elif device_strings[4] == 'T3-317-13': frame_ok = True
             elif device_strings[5] == 'T3S-A13': frame_ok = True
             else:
                 if debug > 0: print('frame meta no match:', device_strings)

--- a/ht301_hacklib.py
+++ b/ht301_hacklib.py
@@ -3,6 +3,7 @@ import numpy as np
 import math
 import cv2
 from datetime import datetime
+from sys import platform
 
 debug = 0
 
@@ -249,7 +250,14 @@ class HT301:
         if video_dev == None:
             video_dev = self.find_device()
 
-        self.cap = cv2.VideoCapture(video_dev)
+        # loosely taken from https://framagit.org/ericb/ir_thermography/-/blob/master/ht301_hacklib/ht301_hacklib.py
+        if platform.startswith('linux'):
+            # ensure v4l2 is used on Linux as gstreamer is broken with OpenCV
+            # see : https://github.com/opencv/opencv/issues/10324
+            self.cap = cv2.VideoCapture(video_dev, cv2.CAP_V4L2)
+        else:
+            self.cap = cv2.VideoCapture(video_dev)
+
         if not self.isHt301(self.cap):
             Exception('device ' + str(video_dev) + ": HT301 or T3S not found!")
 

--- a/ht301_hacklib.py
+++ b/ht301_hacklib.py
@@ -262,6 +262,12 @@ class HT301:
         #self.cap.set(cv2.CAP_PROP_ZOOM, 0x8020)
         self.frame_raw = None
 
+    def __enter__(self):
+        return self
+        
+    def __exit__(self, type, value, traceback):
+        self.release()
+
     def isHt301(self, cap):
         if not cap.isOpened():
             if debug > 0: print('open failed!')


### PR DESCRIPTION
Fixed issue:
- My hti-301 seems to report its device id using a different device string, this string is now checked as well.
- cv2 defaults to gstreamer on my Ubuntu 20.04 which is broken, fix forces to v4l2 on linux

Improvements: 
- For more reliable resource release and convenience I added magic methods to allow:
`
with ht301_hacklib.HT301() as cap:
    ret, frame = cap.read()
    ...
`